### PR TITLE
Add initial Beacon Helm chart with configuration files and templates

### DIFF
--- a/charts/beacon/.helmignore
+++ b/charts/beacon/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/beacon/Chart.lock
+++ b/charts/beacon/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: opentelemetry
+  repository: file://../opentelemetry
+  version: 1.0.1
+digest: sha256:53ebdca0a056d5bf5c5900a2b26552bd1b432c9ae083e86f710c0050b5a1259b
+generated: "2026-05-12T12:08:41.614764-10:00"

--- a/charts/beacon/Chart.yaml
+++ b/charts/beacon/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: beacon
+description: Rotational Beacon — billing, licenses, and deployment management (includes Compass API).
+
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+dependencies:
+  - name: opentelemetry
+    version: ~1.0
+    repository: file://../opentelemetry
+
+home: https://rotational.io
+icon: https://rotational.io/img/favicon.png
+sources:
+  - https://github.com/rotationalio/beacon
+maintainers:
+  - name: rotationalio
+    email: support@rotational.io

--- a/charts/beacon/README.md
+++ b/charts/beacon/README.md
@@ -1,0 +1,5 @@
+# beacon
+
+Helm chart for [Beacon](https://github.com/rotationalio/beacon): StatefulSet with a dedicated PVC for Compass fixtures (`BEACON_COMPASS_FIXTURES`), optional Traefik `IngressRoute`, and OpenTelemetry via the `opentelemetry` library subchart.
+
+See `values.yaml` for defaults. Use `global.origins` for CORS (`BEACON_ALLOWED_ORIGINS`). Set `beacon.auth.authorizedUsers.secretKeyRef` for Basic auth users (comma-separated `user:pass` in the secret value), matching `BEACON_AUTH_AUTHORIZED_USERS`.

--- a/charts/beacon/ci/all-values.yaml
+++ b/charts/beacon/ci/all-values.yaml
@@ -1,0 +1,20 @@
+global:
+  origins:
+    - https://beacon.example.com
+
+fullnameOverride: beacon-ci
+
+ingress:
+  enabled: true
+  hostname: beacon.example.com
+  tls:
+    secretName: tls-certs
+
+beacon:
+  auth:
+    authorizedUsers:
+      value: "ciuser:cipass"
+
+opentelemetry:
+  disabled: true
+  serviceName: beacon-ci

--- a/charts/beacon/templates/NOTES.txt
+++ b/charts/beacon/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Thank you for installing {{ .Chart.Name | title }}.
+
+{{- if .Values.ingress.enabled }}
+Beacon is available at:
+
+  https://{{ .Values.ingress.hostname }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+Beacon is available inside the cluster as service {{ include "beacon.fullname" . }}.
+To connect from your workstation:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "beacon.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8800:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:8800"
+{{- else if contains "NodePort" .Values.service.type }}
+Beacon is exposed as a NodePort service:
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "beacon.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+Beacon is exposed as a LoadBalancer service. It may take a few minutes for the IP to be available:
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "beacon.fullname" . }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "beacon.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- end }}
+
+To upload Compass fixtures, run from the devops repository:
+
+  python3 scripts/compass_to_beacon.py --release {{ .Release.Name }} --fixtures /path/to/beacon/fixtures -n {{ .Release.Namespace }}

--- a/charts/beacon/templates/_environment.tpl
+++ b/charts/beacon/templates/_environment.tpl
@@ -1,0 +1,70 @@
+{{- define "beacon.environment" -}}
+env:
+  - name: BEACON_MAINTENANCE
+    value: {{ .Values.beacon.maintenance | quote }}
+  - name: BEACON_BIND_ADDR
+    value: ":{{ .Values.service.port }}"
+  - name: BEACON_MODE
+    value: {{ include "beacon.mode" . }}
+  - name: BEACON_LOG_LEVEL
+    value: {{ include "beacon.logLevel" . }}
+  - name: BEACON_CONSOLE_LOG
+    value: {{ include "beacon.consoleLog" . }}
+  - name: BEACON_ALLOWED_ORIGINS
+    value: {{ include "beacon.allowOrigins" . }}
+  - name: BEACON_COMPASS_ENABLED
+    value: {{ .Values.beacon.compass.enabled | quote }}
+  - name: BEACON_COMPASS_FIXTURES
+    value: {{ .Values.storage.fixtures.mountPath | quote }}
+  - name: BEACON_TELEMETRY_ENABLED
+    value: {{ .Values.beacon.telemetry.enabled | quote }}
+  {{- if .Values.beacon.telemetry.serviceAddr }}
+  - name: GIMLET_OTEL_SERVICE_ADDR
+    value: {{ .Values.beacon.telemetry.serviceAddr | quote }}
+  {{- end }}
+  {{- if .Values.beacon.auth.authorizedUsers.secretKeyRef }}
+  - name: BEACON_AUTH_AUTHORIZED_USERS
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.beacon.auth.authorizedUsers.secretKeyRef.name }}
+        key: {{ .Values.beacon.auth.authorizedUsers.secretKeyRef.key }}
+  {{- else if .Values.beacon.auth.authorizedUsers.value }}
+  - name: BEACON_AUTH_AUTHORIZED_USERS
+    value: {{ .Values.beacon.auth.authorizedUsers.value | quote }}
+  {{- end }}
+  {{- include "opentelemetry.environment" . | nindent 2 -}}
+{{- end -}}
+
+{{- define "beacon.logLevel" -}}
+{{- if .Values.beacon.logLevel -}}
+{{ .Values.beacon.logLevel | quote }}
+{{- else -}}
+{{ .Values.global.logging.level | quote }}
+{{- end -}}
+{{- end -}}
+
+{{- define "beacon.consoleLog" -}}
+{{- if .Values.beacon.consoleLog -}}
+{{ .Values.beacon.consoleLog | quote }}
+{{- else -}}
+{{ .Values.global.logging.console | quote }}
+{{- end -}}
+{{- end -}}
+
+{{- define "beacon.mode" -}}
+{{- if .Values.beacon.mode -}}
+{{ .Values.beacon.mode | quote }}
+{{- else -}}
+{{ .Values.global.mode | quote }}
+{{- end -}}
+{{- end -}}
+
+{{- define "beacon.allowOrigins" -}}
+{{- if .Values.beacon.allowOrigins }}
+{{- join "," .Values.beacon.allowOrigins | quote -}}
+{{- else if .Values.global.origins -}}
+{{- join "," .Values.global.origins | quote -}}
+{{- else -}}
+"http://localhost:8800"
+{{- end -}}
+{{- end -}}

--- a/charts/beacon/templates/_helpers.tpl
+++ b/charts/beacon/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{- define "beacon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "beacon.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "beacon.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "beacon.labels" -}}
+helm.sh/chart: {{ include "beacon.chart" . }}
+{{ include "beacon.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: beacon
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "beacon.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "beacon.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "beacon.podAnnotations" -}}
+{{- if or .Values.annotations .Values.pod.annotations }}
+annotations:
+  {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.pod.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "beacon.volumeMounts" -}}
+volumeMounts:
+  - name: {{ include "beacon.name" . }}-fixtures
+    mountPath: {{ .Values.storage.fixtures.mountPath }}
+{{- end }}

--- a/charts/beacon/templates/ingress.yaml
+++ b/charts/beacon/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: {{ .Values.ingress.apiVersion }}
+kind: {{ default "IngressRoute" .Values.ingress.className }}
+metadata:
+  name: {{ include "beacon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "beacon.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  entryPoints:
+    {{- toYaml .Values.ingress.entryPoints | nindent 4 }}
+  routes:
+    - match: Host(`{{ .Values.ingress.hostname }}`)
+      kind: Rule
+      services:
+        - name: {{ include "beacon.fullname" . }}
+          port: {{ .Values.service.port }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/beacon/templates/service.yaml
+++ b/charts/beacon/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "beacon.fullname" . }}
+  labels:
+    {{- include "beacon.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "beacon.selectorLabels" . | nindent 4 }}

--- a/charts/beacon/templates/statefulset.yaml
+++ b/charts/beacon/templates/statefulset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "beacon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "beacon.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "beacon.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "beacon.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- include "beacon.podAnnotations" . | nindent 6 }}
+      labels:
+        {{- include "beacon.selectorLabels" . | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containers.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- include "beacon.volumeMounts" . | nindent 10 }}
+          {{- include "beacon.environment" . | nindent 10 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "beacon.name" $ }}-fixtures
+      spec:
+        {{- with .Values.storage.fixtures.spec -}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/beacon/values.yaml
+++ b/charts/beacon/values.yaml
@@ -1,0 +1,95 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: rotationalio/beacon
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+
+global:
+  origins: []
+  logging:
+    level: info
+    console: false
+  mode: release
+
+beacon:
+  maintenance: false
+  mode: null
+  logLevel: null
+  consoleLog: null
+  allowOrigins: null
+
+  compass:
+    enabled: true
+
+  auth:
+    authorizedUsers:
+      value: ""
+      secretKeyRef: null
+
+  telemetry:
+    enabled: true
+    serviceAddr: ""
+
+pod:
+  annotations: {}
+  labels: {}
+  securityContext: {}
+  resources: {}
+
+containers:
+  securityContext: {}
+
+storage:
+  fixtures:
+    mountPath: /data/fixtures
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 2Gi
+
+service:
+  type: ClusterIP
+  port: 8800
+
+ingress:
+  enabled: false
+  apiVersion: traefik.io/v1alpha1
+  className: IngressRoute
+  hostname: ""
+  annotations: {}
+  entryPoints:
+    - websecure
+  tls: {}
+
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: 8800
+    httpHeaders:
+      - name: X-Kubernetes-Probe
+        value: liveness
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8800
+    httpHeaders:
+      - name: X-Kubernetes-Probe
+        value: readiness
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+annotations: {}


### PR DESCRIPTION
### Scope of changes

Added initial Beacon helm chart with config and templates. Setup mostly like Quarterdeck's chart with a statefulset and PVC for the fixtures. I hard-coded the replica count to 1 for this service, and set it for `beacon.rotational.app` as a hostname.

[Here](https://github.com/rotationalio/helm-charts/pull/30#issuecomment-4437093297) is a rendering of the CI values

### Type of change

- [ ] update app version
- [x] new objects/feature
- [x] new/additional configuration
- [x] documentation
- [ ] other (describe)

### Author checklist

- [ ] I have manually debugged the charts using `helm debug`
- [ ] I have updated any affected `values.schema.json` files
- [ ] I have updated the Chart Version for any affected charts
